### PR TITLE
Separate preview and production builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 HUGO_VERSION ?= 0.74.0
 CONTAINER_RUNTIME ?= docker
+# Show build warnings, posts tagged as draft, and posts with a future date
+PREVIEW_ARGS = --path-warnings --verbose --buildDrafts --buildFuture
 
 install: checkDep
 	@echo Installing AsciiDoctor
@@ -11,12 +13,21 @@ checkDep:
 	@command -v hugo > /dev/null && hugo version || (echo "Error hugo is not detected. Hugo needs to be installed and the 'hugo' binary available on the path"; exit 1)
 	@command -v gem > /dev/null && printf "Gem " && gem -v || (echo "Error gem is not detected. The Ruby 'gem' command needs to be on the path"; exit 1)
 
-serve:
-	@hugo serve
+# Preview build for local builds and Netlify previews
+build-preview:
+	@echo Deleting public \(build output\) directory
+	@rm -rf public
+	@hugo version
+	hugo $(PREVIEW_ARGS)
 
+# Production build in Netlify
 build:
 	rm -rf public
+	@hugo version
 	hugo
+
+serve:
+	@hugo $(PREVIEW_ARGS) serve
 
 # muffet - checks for broken links - you have to have hugo running for this to work
 muffet:
@@ -34,5 +45,7 @@ hugo-docker:
 .PHONY: hugo-serve
 hugo-serve: hugo-docker
 	@mkdir -p ./resources/_gen/images && mkdir -p ./resources/_gen/assets
-	@${CONTAINER_RUNTIME} run -t -i --sig-proxy=true --rm --mount type=bind,src=$(shell pwd),dst=/site -w /site -p 1313:1313 docs-developer-blog/hugo:${HUGO_VERSION} /hugo serve --baseURL "http://localhost:1313/" --bind 0.0.0.0 --disableFastRender
+	@${CONTAINER_RUNTIME} run -t -i --sig-proxy=true --rm --mount type=bind,src=$(shell pwd),dst=/site \
+		-w /site -p 1313:1313 docs-developer-blog/hugo:${HUGO_VERSION} /hugo serve $(PREVIEW_ARGS) \
+		--baseURL "http://localhost:1313/" --bind 0.0.0.0 --disableFastRender
 	@rm -rf ./resources

--- a/README.adoc
+++ b/README.adoc
@@ -41,9 +41,20 @@ Alternatively, use the `make install` command to install Asciidoctor by using li
 and Bundler. You need to have the `gem` command in your path. For more information, see the
 link:https://rubygems.org/pages/download[Ruby Gem installation docs].
 
-====  Start a local server
+====  Build the documentation locally
 
-To view documents on your local site, you must start the Hugo server on your device.
+Build your content locally and check for build errors.
+
+1. Change directory to the root directory of your document repository.
+2. Run the following command:
+
+```sh
+make build-preview
+```
+
+====  Start a local web server
+
+To preview documents in a web browser such as Chrome, start the Hugo server on your device.
 
 Hugo has a live `serve` command that runs a small, lightweight web server on your computer so you can
 test your site locally without needing to upload it anywhere.  As you make changes to files in your project,

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,7 @@
   publish = "public"
 
 [context.deploy-preview]
+  command = "make build-preview"
   publish = "public"
 
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
 [build.environment]
-  YARN_VERSION = "1.22.4"
-  NPM_VERSION = "6.14.5"
+  HUGO_VERSION = "0.74.0"
 
 [build]
   command = "make build"


### PR DESCRIPTION
- Separate the preview and production builds
- Set Netlify Hugo version to match Makefile Hugo version
- Increase verbosity on preview builds
- Preview build shows draft and future content
- Log the Hugo version
- Update README